### PR TITLE
Add user account pages

### DIFF
--- a/app/accounts/login/page.tsx
+++ b/app/accounts/login/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { login, LoginData } from '@/lib/accounts';
+
+export default function LoginPage() {
+  const [form, setForm] = useState<LoginData>({ username: '', password: '' });
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await login(form);
+      router.push('/');
+    } catch (err: any) {
+      setError('Erreur de connexion');
+    }
+  };
+
+  return (
+    <main className="container mx-auto py-12 px-4 max-w-md">
+      <h1 className="text-2xl font-bold mb-4 text-center">Connexion</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          value={form.username}
+          onChange={(e) => setForm({ ...form, username: e.target.value })}
+          placeholder="Nom d'utilisateur"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <input
+          type="password"
+          value={form.password}
+          onChange={(e) => setForm({ ...form, password: e.target.value })}
+          placeholder="Mot de passe"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button
+          type="submit"
+          className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700"
+        >
+          Se connecter
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/accounts/profile/page.tsx
+++ b/app/accounts/profile/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { logout, cancelAccount } from '@/lib/accounts';
+
+export default function ProfilePage() {
+  const [message, setMessage] = useState('');
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+      router.push('/');
+    } catch {
+      setMessage('Erreur lors de la déconnexion');
+    }
+  };
+
+  const handleCancel = async () => {
+    try {
+      await cancelAccount();
+      router.push('/');
+    } catch {
+      setMessage('Erreur lors de la suppression du compte');
+    }
+  };
+
+  return (
+    <main className="container mx-auto py-12 px-4 max-w-md space-y-4">
+      <h1 className="text-2xl font-bold text-center">Mon compte</h1>
+      {message && <p className="text-red-600 text-sm">{message}</p>}
+      <button
+        onClick={handleLogout}
+        className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700"
+      >
+        Se déconnecter
+      </button>
+      <button
+        onClick={handleCancel}
+        className="w-full bg-red-600 text-white py-2 rounded hover:bg-red-700"
+      >
+        Supprimer mon compte
+      </button>
+    </main>
+  );
+}

--- a/app/accounts/register/page.tsx
+++ b/app/accounts/register/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { register, RegisterData } from '@/lib/accounts';
+
+export default function RegisterPage() {
+  const [form, setForm] = useState<RegisterData>({
+    username: '',
+    email: '',
+    password: '',
+  });
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await register(form);
+      router.push('/accounts/login');
+    } catch (err: any) {
+      setError('Erreur lors de l\'inscription');
+    }
+  };
+
+  return (
+    <main className="container mx-auto py-12 px-4 max-w-md">
+      <h1 className="text-2xl font-bold mb-4 text-center">Inscription</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          value={form.username}
+          onChange={(e) => setForm({ ...form, username: e.target.value })}
+          placeholder="Nom d'utilisateur"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <input
+          type="email"
+          value={form.email}
+          onChange={(e) => setForm({ ...form, email: e.target.value })}
+          placeholder="Email"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <input
+          type="password"
+          value={form.password}
+          onChange={(e) => setForm({ ...form, password: e.target.value })}
+          placeholder="Mot de passe"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button
+          type="submit"
+          className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700"
+        >
+          S'inscrire
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -57,6 +57,8 @@ export default function Navbar() {
     { href: '/', label: 'ACCUEIL' },
     { href: '/about', label: 'A PROPOS' },
     { href: '/products', label: 'NOS PRODUITS' },
+    { href: '/accounts/login', label: 'CONNEXION' },
+    { href: '/accounts/register', label: 'INSCRIPTION' },
   ];
 
   return (

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1,0 +1,32 @@
+import { api } from './api';
+
+export interface RegisterData {
+  username: string;
+  email: string;
+  password: string;
+}
+
+export interface LoginData {
+  username: string;
+  password: string;
+}
+
+export async function register(data: RegisterData) {
+  const res = await api.post('/accounts/register/', data);
+  return res.data;
+}
+
+export async function login(data: LoginData) {
+  const res = await api.post('/accounts/login/', data);
+  return res.data;
+}
+
+export async function logout() {
+  const res = await api.post('/accounts/logout/');
+  return res.data;
+}
+
+export async function cancelAccount() {
+  const res = await api.delete('/accounts/cancel/');
+  return res.data;
+}


### PR DESCRIPTION
## Summary
- hook up account endpoints via `lib/accounts.ts`
- add registration, login, and profile pages using these endpoints
- expose account links in the navbar

## Testing
- `npm run lint` *(fails: `next` not found)*