### PR TITLE
Add Google Analytics tracking script

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,23 @@
 import type { ReactNode } from 'react';
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
+import Script from 'next/script';
 import './globals.css';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="fr">
+      <head>
+        <Script async src="https://www.googletagmanager.com/gtag/js?id=G-MFV8XCTVGF" />
+        <Script id="gtag-init">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-MFV8XCTVGF');
+          `}
+        </Script>
+      </head>
       <body className="flex flex-col min-h-screen">
         <Navbar />
         <div className="flex-grow">


### PR DESCRIPTION
## Summary
- load Google Analytics script in the root layout
- initialize gtag with site ID `G-MFV8XCTVGF`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443234fa0c832c8797b1c23ffbb12f