### PR TITLE
Add OTP verification and auth state

### DIFF
--- a/app/accounts/login/page.tsx
+++ b/app/accounts/login/page.tsx
@@ -11,7 +11,8 @@ export default function LoginPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await login(form);
+      const data = await login(form);
+      localStorage.setItem('user', JSON.stringify(data));
       router.push('/');
     } catch (err: any) {
       setError('Erreur de connexion');

--- a/app/accounts/profile/page.tsx
+++ b/app/accounts/profile/page.tsx
@@ -10,6 +10,7 @@ export default function ProfilePage() {
   const handleLogout = async () => {
     try {
       await logout();
+      localStorage.removeItem('user');
       router.push('/');
     } catch {
       setMessage('Erreur lors de la déconnexion');
@@ -19,6 +20,7 @@ export default function ProfilePage() {
   const handleCancel = async () => {
     try {
       await cancelAccount();
+      localStorage.removeItem('user');
       router.push('/');
     } catch {
       setMessage('Erreur lors de la suppression du compte');

--- a/app/accounts/register/page.tsx
+++ b/app/accounts/register/page.tsx
@@ -8,6 +8,7 @@ export default function RegisterPage() {
     username: '',
     email: '',
     password: '',
+    role: 'customer',
   });
   const [error, setError] = useState('');
   const router = useRouter();
@@ -15,8 +16,12 @@ export default function RegisterPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await register(form);
-      router.push('/accounts/login');
+      const res = await register(form);
+      if (form.email) {
+        router.push(`/accounts/verify-otp?email=${encodeURIComponent(form.email)}`);
+      } else {
+        router.push('/accounts/login');
+      }
     } catch (err: any) {
       setError('Erreur lors de l\'inscription');
     }
@@ -42,6 +47,15 @@ export default function RegisterPage() {
           className="w-full border px-3 py-2 rounded"
           required
         />
+        <select
+          value={form.role}
+          onChange={(e) => setForm({ ...form, role: e.target.value })}
+          className="w-full border px-3 py-2 rounded"
+        >
+          <option value="customer">Client</option>
+          <option value="seller">Vendeur</option>
+          <option value="admin">Admin</option>
+        </select>
         <input
           type="password"
           value={form.password}

--- a/app/accounts/verify-otp/page.tsx
+++ b/app/accounts/verify-otp/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { verifyOTP, VerifyOTPData } from '@/lib/accounts';
+
+export default function VerifyOTPPage() {
+  const params = useSearchParams();
+  const emailParam = params.get('email') || '';
+  const [form, setForm] = useState<VerifyOTPData>({ email: emailParam, code: '' });
+  const [message, setMessage] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await verifyOTP(form);
+      setMessage('OTP validé, vous pouvez vous connecter');
+      setTimeout(() => router.push('/accounts/login'), 1500);
+    } catch (err: any) {
+      setMessage("Code invalide ou expiré");
+    }
+  };
+
+  return (
+    <main className="container mx-auto py-12 px-4 max-w-md">
+      <h1 className="text-2xl font-bold mb-4 text-center">Vérification OTP</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          value={form.email}
+          onChange={(e) => setForm({ ...form, email: e.target.value })}
+          placeholder="Email"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <input
+          type="text"
+          value={form.code}
+          onChange={(e) => setForm({ ...form, code: e.target.value })}
+          placeholder="Code OTP"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        {message && <p className="text-red-600 text-sm">{message}</p>}
+        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">
+          Vérifier
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -13,10 +13,15 @@ interface CartItem {
 export default function CartPage() {
   const [items, setItems] = useState<CartItem[]>([]);
   const [loading, setLoading] = useState(true);
-  const userId = 1; // TODO: replace with actual user id
   const router = useRouter();
+  const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
+  const userId = stored ? JSON.parse(stored).id : null;
 
   useEffect(() => {
+    if (!userId) {
+      router.push('/accounts/login');
+      return;
+    }
     viewCart(userId)
       .then(setItems)
       .catch(() => setItems([]))

--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -11,9 +11,14 @@ interface Order {
 export default function OrdersPage() {
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
-  const userId = 1; // TODO: replace with actual user id
+  const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
+  const userId = stored ? JSON.parse(stored).id : null;
 
   useEffect(() => {
+    if (!userId) {
+      window.location.href = '/accounts/login';
+      return;
+    }
     listOrders(userId)
       .then(setOrders)
       .catch(() => setOrders([]))

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -17,6 +17,7 @@ type Product = {
 export default function Navbar() {
   const [searchQuery, setSearchQuery] = useState('');
   const [suggestions, setSuggestions] = useState<Product[]>([]);
+  const [user, setUser] = useState<any>(null);
   const router = useRouter();
   const pathname = usePathname();
 
@@ -53,15 +54,22 @@ export default function Navbar() {
     fetchSuggestions();
   }, [searchQuery]);
 
+  useEffect(() => {
+    const stored = localStorage.getItem('user');
+    if (stored) setUser(JSON.parse(stored));
+  }, []);
+
   const navLinks = [
     { href: '/', label: 'ACCUEIL' },
     { href: '/about', label: 'A PROPOS' },
     { href: '/products', label: 'NOS PRODUITS' },
     { href: '/cart', label: 'PANIER' },
     { href: '/orders', label: 'COMMANDES' },
-    { href: '/accounts/login', label: 'CONNEXION' },
-    { href: '/accounts/register', label: 'INSCRIPTION' },
-  ];
+    user
+      ? { href: '/accounts/profile', label: 'MON COMPTE' }
+      : { href: '/accounts/login', label: 'CONNEXION' },
+    !user && { href: '/accounts/register', label: 'INSCRIPTION' },
+  ].filter(Boolean);
 
   return (
     <header className="bg-white shadow-sm py-4 relative z-50">

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -2,8 +2,9 @@ import { api } from './api';
 
 export interface RegisterData {
   username: string;
-  email: string;
+  email?: string;
   password: string;
+  role: string;
 }
 
 export interface LoginData {
@@ -28,5 +29,15 @@ export async function logout() {
 
 export async function cancelAccount() {
   const res = await api.delete('/accounts/cancel/');
+  return res.data;
+}
+
+export interface VerifyOTPData {
+  email: string;
+  code: string;
+}
+
+export async function verifyOTP(data: VerifyOTPData) {
+  const res = await api.post('/accounts/verify-otp/', data);
   return res.data;
 }


### PR DESCRIPTION
## Summary
- expand account utilities to support role and OTP verification
- store session user info in `localStorage` after login
- update registration form with role field and OTP redirection
- add OTP verification page
- clear stored session on logout or account removal
- restrict cart and orders pages to logged users
- show account links in navbar when logged in

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68444306ca7c832cb78620a0f7e6cea2