### PR TITLE
Remove signup navigation; cross link login/register

### DIFF
--- a/app/accounts/login/page.tsx
+++ b/app/accounts/login/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { firebaseLogin } from '@/lib/firebase';
 
 export default function LoginPage() {
@@ -50,6 +51,12 @@ export default function LoginPage() {
           Se connecter
         </button>
       </form>
+      <p className="mt-4 text-sm text-center">
+        Pas encore de compte ?{' '}
+        <Link href="/accounts/register" className="text-blue-600 hover:underline">
+          Inscrivez-vous
+        </Link>
+      </p>
     </main>
   );
 }

--- a/app/accounts/register/page.tsx
+++ b/app/accounts/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { firebaseRegister } from '@/lib/firebase';
+import Link from 'next/link';
 
 export default function RegisterPage() {
   const [form, setForm] = useState({
@@ -67,6 +68,12 @@ export default function RegisterPage() {
           S'inscrire
         </button>
       </form>
+      <p className="mt-4 text-sm text-center">
+        Déjà un compte ?{' '}
+        <Link href="/accounts/login" className="text-blue-600 hover:underline">
+          Connectez-vous
+        </Link>
+      </p>
     </main>
   );
 }

--- a/components/FloatingMenu.tsx
+++ b/components/FloatingMenu.tsx
@@ -50,15 +50,6 @@ export default function FloatingMenu() {
               </li>
               <li>
                 <Link
-                  href="/accounts/register"
-                  className="block px-4 py-2 hover:bg-gray-100"
-                  onClick={() => setOpen(false)}
-                >
-                  Inscription
-                </Link>
-              </li>
-              <li>
-                <Link
                   href="/orders"
                   className="block px-4 py-2 hover:bg-gray-100"
                   onClick={() => setOpen(false)}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -77,10 +77,7 @@ const navLinks: { href: string; label: string }[] = [
   { href: '/orders', label: 'COMMANDES' },
   ...(user
     ? [{ href: '/accounts/profile', label: 'MON COMPTE' }]
-    : [
-        { href: '/accounts/login', label: 'CONNEXION' },
-        { href: '/accounts/register', label: 'INSCRIPTION' },
-      ]),
+    : [{ href: '/accounts/login', label: 'CONNEXION' }]),
 ];
 
   return (


### PR DESCRIPTION
## Summary
- remove sign up link from navigation and floating menu
- add cross-links between login and register pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ae19fd9e0832c8fcfb689be4e2eb7