### PR TITLE
Add cart icon with count

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,6 +6,7 @@ import { useRouter, usePathname } from 'next/navigation';
 import Image from 'next/image';
 import axios from 'axios';
 import { watchAuth } from '@/lib/firebase';
+import { viewCart } from '@/lib/cart';
 
 type Product = {
   id: number;
@@ -19,6 +20,7 @@ export default function Navbar() {
   const [searchQuery, setSearchQuery] = useState('');
   const [suggestions, setSuggestions] = useState<Product[]>([]);
   const [user, setUser] = useState<any>(null);
+  const [cartCount, setCartCount] = useState(0);
   const router = useRouter();
   const pathname = usePathname();
 
@@ -67,6 +69,22 @@ export default function Navbar() {
       }
     });
     return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
+    const id = stored ? JSON.parse(stored).id : undefined;
+    viewCart(id).then((items) => {
+      const total = items.reduce((sum: number, it: any) => sum + (it.quantity || 0), 0);
+      setCartCount(total);
+    });
+    function handle(e: any) {
+      const items = e.detail || [];
+      const total = items.reduce((sum: number, it: any) => sum + (it.quantity || 0), 0);
+      setCartCount(total);
+    }
+    window.addEventListener('cart-changed', handle);
+    return () => window.removeEventListener('cart-changed', handle);
   }, []);
 
 const navLinks: { href: string; label: string }[] = [
@@ -165,6 +183,14 @@ const navLinks: { href: string; label: string }[] = [
             </ul>
           )}
         </div>
+        <Link href="/cart" className="relative text-2xl">
+          <span role="img" aria-label="Panier">🛒</span>
+          {cartCount > 0 && (
+            <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center">
+              {cartCount}
+            </span>
+          )}
+        </Link>
       </div>
     </header>
   );

--- a/lib/cart.ts
+++ b/lib/cart.ts
@@ -14,6 +14,12 @@ export interface UpdateCartData {
 
 const LOCAL_KEY = 'cart';
 
+function emitCart(items: CartItemData[]) {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('cart-changed', { detail: items }));
+  }
+}
+
 function readLocalCart(): CartItemData[] {
   if (typeof window === 'undefined') return [];
   try {
@@ -26,6 +32,7 @@ function readLocalCart(): CartItemData[] {
 function saveLocalCart(items: CartItemData[]) {
   if (typeof window !== 'undefined') {
     localStorage.setItem(LOCAL_KEY, JSON.stringify(items));
+    emitCart(items);
   }
 }
 
@@ -34,6 +41,8 @@ export async function addToCart(data: CartItemData) {
   const user = stored ? JSON.parse(stored) : null;
   if (user) {
     const res = await api.post('/cart/add/', data);
+    const items = await viewCart(user.id);
+    emitCart(items);
     return res.data;
   }
   const items = readLocalCart();
@@ -54,6 +63,8 @@ export async function updateCartItem(data: UpdateCartData) {
   const user = stored ? JSON.parse(stored) : null;
   if (user) {
     const res = await api.post('/cart/update/', data);
+    const items = await viewCart(user.id);
+    emitCart(items);
     return res.data;
   }
   const items = readLocalCart();
@@ -70,6 +81,8 @@ export async function removeFromCart(item_id: number) {
   const user = stored ? JSON.parse(stored) : null;
   if (user) {
     const res = await api.post('/cart/remove/', { item_id });
+    const items = await viewCart(user.id);
+    emitCart(items);
     return res.data;
   }
   const items = readLocalCart().filter(


### PR DESCRIPTION
## Summary
- track cart changes and emit events
- show cart count in navbar
- type `reduce` accumulator for strict TS

## Testing
- `npm run lint`
- `npm run build` *(fails: `Erreur génération sitemap : TypeError: fetch failed`)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5915b00832ca131effc92f9d3d1