### PR TITLE
Enhance WhatsApp checkout and add detail page cart actions

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -84,7 +84,7 @@ export default function CartPage() {
     if (!userId) {
       localStorage.removeItem('cart');
     }
-    window.location.href = url;
+    window.open(url, '_blank');
   };
 
   if (loading) return <p className="p-4">Chargement...</p>;

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, ResolvingMetadata } from 'next';
+import AddToCart from '@/components/AddToCart';
 
 // 🔁 Récupère l'image
 function getImageUrl(product: any): string {
@@ -118,19 +119,24 @@ export default async function ProductDetailPage({
             </p>
           )}
 
-          <a
-            href={whatsappLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center mt-4 bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-4 rounded-full transition"
-          >
-            <img
-              src="https://upload.wikimedia.org/wikipedia/commons/6/6b/WhatsApp.svg"
-              alt="WhatsApp"
-              className="w-5 h-5 mr-2"
+          <div className="mt-4 space-y-2 sm:space-y-0 sm:flex sm:space-x-2">
+            <a
+              href={whatsappLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-4 rounded-full transition w-full justify-center"
+            >
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/6/6b/WhatsApp.svg"
+                alt="WhatsApp"
+                className="w-5 h-5 mr-2"
+              />
+              Acheter
+            </a>
+            <AddToCart
+              product={{ id: product.id, name: product.name, imageUrl }}
             />
-            Acheter
-          </a>
+          </div>
 
           <div className="mt-4 text-sm text-gray-700 space-y-1">
             <p><strong>Catégorie :</strong> {product.categ_id}</p>

--- a/components/AddToCart.tsx
+++ b/components/AddToCart.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+import { addToCart, updateCartItem, removeFromCart } from '@/lib/cart';
+
+interface ProductInfo {
+  id: number;
+  name: string;
+  imageUrl?: string;
+}
+
+export default function AddToCart({ product }: { product: ProductInfo }) {
+  const [qty, setQty] = useState(0);
+  const [itemId, setItemId] = useState<number | null>(null);
+
+  const handleAdd = async () => {
+    const res = await addToCart({
+      product_id: product.id,
+      quantity: 1,
+      product_name: product.name,
+      product_image: product.imageUrl,
+    });
+    if (res && typeof res === 'object' && 'id' in res) {
+      setItemId((res as any).id as number);
+    }
+    setQty(1);
+  };
+
+  const increment = async () => {
+    const newQty = qty + 1;
+    await updateCartItem({ item_id: itemId ?? product.id, quantity: newQty });
+    setQty(newQty);
+  };
+
+  const decrement = async () => {
+    const newQty = qty - 1;
+    if (newQty <= 0) {
+      await removeFromCart(itemId ?? product.id);
+      setQty(0);
+      setItemId(null);
+    } else {
+      await updateCartItem({ item_id: itemId ?? product.id, quantity: newQty });
+      setQty(newQty);
+    }
+  };
+
+  if (qty === 0) {
+    return (
+      <button
+        onClick={handleAdd}
+        className="w-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold py-2 px-4 rounded-full transition"
+      >
+        Ajouter au panier
+      </button>
+    );
+  }
+
+  return (
+    <div className="inline-flex border rounded w-full justify-center">
+      <button onClick={decrement} className="px-3 bg-gray-200 rounded-l">
+        -
+      </button>
+      <span className="px-4 flex items-center">{qty}</span>
+      <button onClick={increment} className="px-3 bg-gray-200 rounded-r">
+        +
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow cart checkout to open WhatsApp in a new tab
- add `AddToCart` component for reusable cart actions
- offer WhatsApp and cart actions on product detail pages

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b3a179524832c820b06b0c92e7f31