### PR TITLE
Fix WhatsApp cart message with totals

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -9,6 +9,7 @@ interface CartItem {
   product_id?: number;
   product_name?: string;
   product_image?: string;
+  price?: number;
   quantity: number;
 }
 
@@ -70,21 +71,35 @@ export default function CartPage() {
   const decrement = (item: CartItem) => updateQuantity(item, item.quantity - 1);
 
   const handleCheckout = async () => {
+    const newWindow = window.open('', '_blank');
     try {
       await createOrder({ items });
     } catch (err) {
       console.error('Failed to create order', err);
     }
-    const text = items
-      .map((it) => `${it.product_name} x${it.quantity}`)
-      .join(', ');
-    const url = `https://wa.me/22588899965?text=${encodeURIComponent(
-      'Bonjour, je souhaite commander: ' + text
-    )}`;
+    const format = (n: number) => n.toLocaleString('fr-FR');
+    const lines = items.map((it) => {
+      const unit = it.price ?? 0;
+      const lineTotal = unit * it.quantity;
+      return `- ${it.product_name} x${it.quantity} = ${format(lineTotal)} FCFA`;
+    });
+    const total = items.reduce(
+      (sum, it) => sum + (it.price ?? 0) * it.quantity,
+      0
+    );
+    const message =
+      'Bonjour, je souhaite commander:\n' +
+      lines.join('\n') +
+      `\nTotal: ${format(total)} FCFA`;
+    const url = `https://wa.me/22588899965?text=${encodeURIComponent(message)}`;
     if (!userId) {
       localStorage.removeItem('cart');
     }
-    window.location.href = url;
+    if (newWindow) {
+      newWindow.location.href = url;
+    } else {
+      window.open(url, '_blank');
+    }
   };
 
   if (loading) return <p className="p-4">Chargement...</p>;

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, ResolvingMetadata } from 'next';
+import AddToCart from '@/components/AddToCart';
 
 // 🔁 Récupère l'image
 function getImageUrl(product: any): string {
@@ -118,19 +119,29 @@ export default async function ProductDetailPage({
             </p>
           )}
 
-          <a
-            href={whatsappLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center mt-4 bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-4 rounded-full transition"
-          >
-            <img
-              src="https://upload.wikimedia.org/wikipedia/commons/6/6b/WhatsApp.svg"
-              alt="WhatsApp"
-              className="w-5 h-5 mr-2"
+          <div className="mt-4 space-y-2 sm:space-y-0 sm:flex sm:space-x-2">
+            <a
+              href={whatsappLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-4 rounded-full transition w-full justify-center"
+            >
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/6/6b/WhatsApp.svg"
+                alt="WhatsApp"
+                className="w-5 h-5 mr-2"
+              />
+              Acheter
+            </a>
+            <AddToCart
+              product={{
+                id: product.id,
+                name: product.name,
+                imageUrl,
+                price: product.list_price,
+              }}
             />
-            Acheter
-          </a>
+          </div>
 
           <div className="mt-4 text-sm text-gray-700 space-y-1">
             <p><strong>Catégorie :</strong> {product.categ_id}</p>

--- a/components/AddToCart.tsx
+++ b/components/AddToCart.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+import { addToCart, updateCartItem, removeFromCart } from '@/lib/cart';
+
+interface ProductInfo {
+  id: number;
+  name: string;
+  imageUrl?: string;
+  price?: number;
+}
+
+export default function AddToCart({ product }: { product: ProductInfo }) {
+  const [qty, setQty] = useState(0);
+  const [itemId, setItemId] = useState<number | null>(null);
+
+  const handleAdd = async () => {
+    const res = await addToCart({
+      product_id: product.id,
+      quantity: 1,
+      product_name: product.name,
+      product_image: product.imageUrl,
+      price: product.price,
+    });
+    if (res && typeof res === 'object' && 'id' in res) {
+      setItemId((res as any).id as number);
+    }
+    setQty(1);
+  };
+
+  const increment = async () => {
+    const newQty = qty + 1;
+    await updateCartItem({ item_id: itemId ?? product.id, quantity: newQty });
+    setQty(newQty);
+  };
+
+  const decrement = async () => {
+    const newQty = qty - 1;
+    if (newQty <= 0) {
+      await removeFromCart(itemId ?? product.id);
+      setQty(0);
+      setItemId(null);
+    } else {
+      await updateCartItem({ item_id: itemId ?? product.id, quantity: newQty });
+      setQty(newQty);
+    }
+  };
+
+  if (qty === 0) {
+    return (
+      <button
+        onClick={handleAdd}
+        className="w-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold py-2 px-4 rounded-full transition"
+      >
+        Ajouter au panier
+      </button>
+    );
+  }
+
+  return (
+    <div className="inline-flex border rounded w-full justify-center">
+      <button onClick={decrement} className="px-3 bg-gray-200 rounded-l">
+        -
+      </button>
+      <span className="px-4 flex items-center">{qty}</span>
+      <button onClick={increment} className="px-3 bg-gray-200 rounded-r">
+        +
+      </button>
+    </div>
+  );
+}

--- a/components/ProductCard.jsx
+++ b/components/ProductCard.jsx
@@ -64,6 +64,7 @@ export default function ProductCard({ product }) {
                 quantity: 1,
                 product_name: product.name,
                 product_image: product.imageUrl,
+                price: product.list_price,
               });
               if (res && typeof res === 'object' && 'id' in res) {
                 setItemId(res.id);

--- a/lib/cart.ts
+++ b/lib/cart.ts
@@ -5,6 +5,7 @@ export interface CartItemData {
   quantity: number;
   product_name?: string;
   product_image?: string;
+  price?: number;
 }
 
 export interface UpdateCartData {
@@ -51,6 +52,7 @@ export async function addToCart(data: CartItemData) {
     existing.quantity += data.quantity;
     if (data.product_name) existing.product_name = data.product_name;
     if (data.product_image) existing.product_image = data.product_image;
+    if (data.price) existing.price = data.price;
   } else {
     items.push(data);
   }


### PR DESCRIPTION
## Summary
- store item price in the cart
- include price when adding products to the cart
- show item prices and order total in the WhatsApp checkout link

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b3a179524832c820b06b0c92e7f31