### PR TITLE
Add icons and adjust menu overlay

### DIFF
--- a/components/FloatingMenu.tsx
+++ b/components/FloatingMenu.tsx
@@ -36,7 +36,7 @@ export default function FloatingMenu() {
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: -10 }}
             transition={{ duration: 0.2 }}
-            className="mt-2 w-40 bg-white rounded-md shadow-lg overflow-hidden"
+            className="mt-2 w-40 bg-white/80 rounded-md shadow-lg overflow-hidden"
           >
             <ul className="py-2 text-sm">
               <li>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,12 +1,21 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type ReactElement } from 'react';
 import Link from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
 import Image from 'next/image';
 import axios from 'axios';
 import { watchAuth } from '@/lib/firebase';
 import { viewCart, type CartItemData } from '@/lib/cart';
+import {
+  FaHome,
+  FaBoxOpen,
+  FaShoppingCart,
+  FaClipboardList,
+  FaSignInAlt,
+  FaInfoCircle,
+  FaUser,
+} from 'react-icons/fa';
 
 type Product = {
   id: number;
@@ -93,15 +102,20 @@ export default function Navbar() {
     return () => window.removeEventListener('cart-changed', handle);
   }, []);
 
-const navLinks: { href: string; label: string }[] = [
-  { href: '/', label: 'ACCUEIL' },
-  { href: '/about', label: 'A PROPOS' },
-  { href: '/products', label: 'NOS PRODUITS' },
-  { href: '/cart', label: 'PANIER' },
-  { href: '/orders', label: 'COMMANDES' },
+const navLinks: {
+  href: string;
+  label: string;
+  icon: ReactElement;
+  showCount?: boolean;
+}[] = [
+  { href: '/', label: 'ACCUEIL', icon: <FaHome /> },
+  { href: '/products', label: 'NOS PRODUITS', icon: <FaBoxOpen /> },
+  { href: '/cart', label: 'PANIER', icon: <FaShoppingCart />, showCount: true },
+  { href: '/orders', label: 'COMMANDES', icon: <FaClipboardList /> },
   ...(user
-    ? [{ href: '/accounts/profile', label: 'MON COMPTE' }]
-    : [{ href: '/accounts/login', label: 'CONNEXION' }]),
+    ? [{ href: '/accounts/profile', label: 'MON COMPTE', icon: <FaUser /> }]
+    : [{ href: '/accounts/login', label: 'CONNEXION', icon: <FaSignInAlt /> }]),
+  { href: '/about', label: 'A PROPOS', icon: <FaInfoCircle /> },
 ];
 
   return (
@@ -123,17 +137,25 @@ const navLinks: { href: string; label: string }[] = [
 
         {/* Navigation centrale */}
         <nav className="flex flex-wrap justify-center gap-4 text-sm font-bold text-orange-500">
-          {navLinks.map(({ href, label }) => (
+          {navLinks.map(({ href, label, icon, showCount }) => (
             <Link
               key={href}
               href={href}
-              className={`px-3 py-2 rounded-md transition-all duration-300 ${
+              className={`flex items-center gap-1 px-3 py-2 rounded-md transition-all duration-300 ${
                 pathname === href
                   ? 'bg-orange-400 text-white'
                   : 'hover:text-blue-600'
               }`}
             >
-              {label}
+              <span className="relative text-lg">
+                {icon}
+                {showCount && cartCount > 0 && (
+                  <span className="absolute -top-2 -right-3 bg-red-500 text-white text-xs rounded-full w-4 h-4 flex items-center justify-center">
+                    {cartCount}
+                  </span>
+                )}
+              </span>
+              <span>{label}</span>
             </Link>
           ))}
         </nav>
@@ -189,14 +211,6 @@ const navLinks: { href: string; label: string }[] = [
             </ul>
           )}
         </div>
-        <Link href="/cart" className="relative text-2xl">
-          <span role="img" aria-label="Panier">🛒</span>
-          {cartCount > 0 && (
-            <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center">
-              {cartCount}
-            </span>
-          )}
-        </Link>
       </div>
     </header>
   );

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "firebase": "^10.11.0",
     "next": "15.2.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-icons": "^4.10.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add `react-icons` dependency
- integrate icons into navigation menu
- make floating menu semi-transparent to prevent covering content

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'react-icons/fa')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684b34a50ad8832c91c4c31a03228d9d