### PR TITLE
Fix collapsed navbar visibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,8 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+body.nav-collapsed .content,
+body.nav-collapsed footer {
+  margin-left: 4rem;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="flex flex-col min-h-screen">
         <Navbar />
         <FirebaseInit />
-        <div className="flex-grow">
+        <div className="flex-grow content">
           {children}
         </div>
         <Footer />

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 
 export default function Footer() {
   return (
-    <footer className="bg-gray-800 text-white">
+    <footer className="bg-gray-800 text-white content">
       <div className="container mx-auto py-8 px-6 grid grid-cols-1 md:grid-cols-3 gap-8">
 
         <div className="flex flex-col items-start">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -90,6 +90,17 @@ export default function Navbar() {
   }, []);
 
   useEffect(() => {
+    if (typeof document !== 'undefined') {
+      const body = document.body;
+      if (collapsed) {
+        body.classList.add('nav-collapsed');
+      } else {
+        body.classList.remove('nav-collapsed');
+      }
+    }
+  }, [collapsed]);
+
+  useEffect(() => {
     const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
     const id = stored ? JSON.parse(stored).id : undefined;
     viewCart(id).then((items) => {
@@ -187,9 +198,9 @@ const navLinks: {
                 )}
               </span>
               <span
-                className={`$ {
+                className={`${
                   collapsed
-                    ? 'absolute left-full ml-2 bg-white px-2 py-1 rounded shadow opacity-0 group-hover:opacity-100 whitespace-nowrap'
+                    ? 'absolute left-full ml-2 bg-white px-2 py-1 rounded shadow opacity-0 group-hover:opacity-100 whitespace-nowrap text-black'
                     : ''
                 }`}
               >


### PR DESCRIPTION
## Summary
- ensure sidebar tooltip text is visible with black text color
- shift page content when sidebar is collapsed
- manage `nav-collapsed` body class from Navbar
- keep footer visible when sidebar is collapsed

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b5e90337c832c95fb52c4faee51fb