### PR TITLE
Add stock management page

### DIFF
--- a/app/stock/page.tsx
+++ b/app/stock/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { listStock, updateStock, type StockItem } from '@/lib/stock';
+
+export default function StockPage() {
+  const [items, setItems] = useState<StockItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
+  const userId = stored ? JSON.parse(stored).id : null;
+
+  useEffect(() => {
+    if (!userId) {
+      window.location.href = '/accounts/login';
+      return;
+    }
+    listStock()
+      .then(setItems)
+      .catch(() => setItems([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleUpdate = async (item: StockItem, qty: number) => {
+    const quantity = Math.max(0, qty);
+    try {
+      await updateStock(item.id, quantity);
+      setItems(items.map((it) => (it.id === item.id ? { ...it, quantity } : it)));
+    } catch (err) {
+      console.error('Failed to update stock', err);
+    }
+  };
+
+  if (loading) return <p className="p-4">Chargement...</p>;
+
+  return (
+    <main className="container mx-auto py-8 px-4 space-y-4">
+      <h1 className="text-2xl font-bold text-center mb-4">Gestion de stock</h1>
+      {items.length === 0 ? (
+        <p>Aucun produit en stock.</p>
+      ) : (
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              <th className="border px-2 py-1 text-left">Produit</th>
+              <th className="border px-2 py-1">Quantité</th>
+              <th className="border px-2 py-1">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr key={item.id}>
+                <td className="border px-2 py-1">{item.name}</td>
+                <td className="border px-2 py-1 text-center">{item.quantity}</td>
+                <td className="border px-2 py-1 text-center space-x-1">
+                  <button
+                    onClick={() => handleUpdate(item, item.quantity + 1)}
+                    className="px-2 bg-gray-200 rounded-l"
+                  >
+                    +
+                  </button>
+                  <button
+                    onClick={() => handleUpdate(item, item.quantity - 1)}
+                    className="px-2 bg-gray-200 rounded-r"
+                  >
+                    -
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </main>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -12,6 +12,7 @@ import {
   FaBoxOpen,
   FaShoppingCart,
   FaClipboardList,
+  FaWarehouse,
   FaSignInAlt,
   FaInfoCircle,
   FaUser,
@@ -132,6 +133,7 @@ const navLinks: {
   { href: '/products', label: 'NOS PRODUITS', icon: <FaBoxOpen /> },
   { href: '/cart', label: 'PANIER', icon: <FaShoppingCart />, showCount: true },
   { href: '/orders', label: 'COMMANDES', icon: <FaClipboardList /> },
+  ...(user ? [{ href: '/stock', label: 'STOCK', icon: <FaWarehouse /> }] : []),
   ...(user
     ? [{ href: '/accounts/profile', label: 'MON COMPTE', icon: <FaUser /> }]
     : [{ href: '/accounts/login', label: 'CONNEXION', icon: <FaSignInAlt /> }]),

--- a/lib/stock.ts
+++ b/lib/stock.ts
@@ -1,0 +1,18 @@
+import { api } from './api';
+
+export interface StockItem {
+  id: number;
+  name: string;
+  quantity: number;
+  [key: string]: any;
+}
+
+export async function listStock() {
+  const res = await api.get('/stock/');
+  return res.data;
+}
+
+export async function updateStock(id: number, quantity: number) {
+  const res = await api.post('/stock/update/', { id, quantity });
+  return res.data;
+}


### PR DESCRIPTION
## Summary
- add library for stock endpoints
- create stock management page with quantity adjustment
- link stock page from navbar for logged-in users
- run lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68651bfffd1c832e855a967653eda036