### PR TITLE
Centralize user handling

### DIFF
--- a/app/accounts/login/page.tsx
+++ b/app/accounts/login/page.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { firebaseLogin } from '@/lib/firebase';
+import { saveCurrentUser } from '@/lib/user';
 
 export default function LoginPage() {
   const [form, setForm] = useState({ email: '', password: '' });
@@ -13,10 +14,7 @@ export default function LoginPage() {
     e.preventDefault();
     try {
       const user = await firebaseLogin(form.email, form.password);
-      localStorage.setItem(
-        'user',
-        JSON.stringify({ id: user.uid, email: user.email, name: user.displayName })
-      );
+      saveCurrentUser({ id: user.uid, email: user.email, name: user.displayName });
       router.push('/');
     } catch (err: any) {
       setError(err.message || 'Erreur de connexion');

--- a/app/accounts/profile/page.tsx
+++ b/app/accounts/profile/page.tsx
@@ -7,6 +7,7 @@ import {
   firebaseUpdatePassword,
 } from '@/lib/firebase';
 import { listOrders } from '@/lib/orders';
+import { getCurrentUser, removeCurrentUser } from '@/lib/user';
 
 export default function ProfilePage() {
   const [message, setMessage] = useState('');
@@ -17,12 +18,11 @@ export default function ProfilePage() {
   const router = useRouter();
 
   useEffect(() => {
-    const stored = localStorage.getItem('user');
-    if (!stored) {
+    const u = getCurrentUser();
+    if (!u) {
       router.push('/accounts/login');
       return;
     }
-    const u = JSON.parse(stored);
     setUser(u);
     listOrders(u.id)
       .then(setOrders)
@@ -33,7 +33,7 @@ export default function ProfilePage() {
   const handleLogout = async () => {
     try {
       await firebaseLogout();
-      localStorage.removeItem('user');
+      removeCurrentUser();
       router.push('/');
     } catch {
       setMessage('Erreur lors de la déconnexion');
@@ -43,7 +43,7 @@ export default function ProfilePage() {
   const handleCancel = async () => {
     try {
       await firebaseDeleteAccount();
-      localStorage.removeItem('user');
+      removeCurrentUser();
       router.push('/');
     } catch {
       setMessage('Erreur lors de la suppression du compte');

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { viewCart, removeFromCart, updateCartItem } from '@/lib/cart';
+import { getCurrentUser } from '@/lib/user';
 import { createOrder } from '@/lib/orders';
 
 interface CartItem {
@@ -29,8 +30,7 @@ export default function CartPage() {
   const [items, setItems] = useState<CartItem[]>([]);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
-  const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
-  const userId = stored ? JSON.parse(stored).id : null;
+  const userId = getCurrentUser()?.id ?? null;
 
   useEffect(() => {
     if (!userId) {

--- a/app/inventory/page.tsx
+++ b/app/inventory/page.tsx
@@ -9,6 +9,7 @@ import {
   type Site,
   type StockEntry,
 } from '@/lib/inventory';
+import { getCurrentUser } from '@/lib/user';
 
 const ADMIN_EMAILS = ['admin@example.com'];
 
@@ -21,13 +22,12 @@ export default function InventoryPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const stored = localStorage.getItem('user');
-    if (!stored) {
+    const user = getCurrentUser();
+    if (!user) {
       window.location.href = '/accounts/login';
       return;
     }
-    const user = JSON.parse(stored);
-    if (!ADMIN_EMAILS.includes(user.email)) {
+    if (!ADMIN_EMAILS.includes(user.email ?? '')) {
       window.location.href = '/';
       return;
     }

--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { listOrders } from '@/lib/orders';
+import { getCurrentUser } from '@/lib/user';
 
 interface Order {
   id: number;
@@ -11,8 +12,7 @@ interface Order {
 export default function OrdersPage() {
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
-  const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
-  const userId = stored ? JSON.parse(stored).id : null;
+  const userId = getCurrentUser()?.id ?? null;
 
   useEffect(() => {
     if (!userId) {

--- a/app/stock/page.tsx
+++ b/app/stock/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { listStock, updateStock, type StockItem } from '@/lib/stock';
+import { getCurrentUser } from '@/lib/user';
 
 export default function StockPage() {
   const [items, setItems] = useState<StockItem[]>([]);
   const [loading, setLoading] = useState(true);
-  const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
-  const userId = stored ? JSON.parse(stored).id : null;
+  const userId = getCurrentUser()?.id ?? null;
 
   useEffect(() => {
     if (!userId) {

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,6 +6,7 @@ import { useRouter, usePathname } from 'next/navigation';
 import Image from 'next/image';
 import axios from 'axios';
 import { watchAuth } from '@/lib/firebase';
+import { getCurrentUser } from '@/lib/user';
 import { viewCart, type CartItemData } from '@/lib/cart';
 import {
   FaHome,
@@ -72,11 +73,8 @@ export default function Navbar() {
   useEffect(() => {
     const unsubscribe = watchAuth((u) => {
       if (u) {
-        const obj = { id: u.uid, email: u.email, name: u.displayName };
-        localStorage.setItem('user', JSON.stringify(obj));
-        setUser(obj);
+        setUser({ id: u.uid, email: u.email, name: u.displayName });
       } else {
-        localStorage.removeItem('user');
         setUser(null);
       }
     });
@@ -103,8 +101,8 @@ export default function Navbar() {
   }, [collapsed]);
 
   useEffect(() => {
-    const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
-    const id = stored ? JSON.parse(stored).id : undefined;
+    const user = getCurrentUser();
+    const id = user?.id;
     viewCart(id).then((items) => {
       const total = items.reduce(
         (sum: number, it: CartItemData) => sum + (it.quantity || 0),

--- a/lib/cart.ts
+++ b/lib/cart.ts
@@ -1,4 +1,5 @@
 import { api } from './api';
+import { getCurrentUser } from './user';
 
 export interface CartItemData {
   product_id: number;
@@ -38,8 +39,7 @@ function saveLocalCart(items: CartItemData[]) {
 }
 
 export async function addToCart(data: CartItemData) {
-  const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
-  const user = stored ? JSON.parse(stored) : null;
+  const user = getCurrentUser();
   if (user) {
     const res = await api.post('/cart/add/', data);
     const items = await viewCart(user.id);
@@ -61,8 +61,7 @@ export async function addToCart(data: CartItemData) {
 }
 
 export async function updateCartItem(data: UpdateCartData) {
-  const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
-  const user = stored ? JSON.parse(stored) : null;
+  const user = getCurrentUser();
   if (user) {
     const res = await api.post('/cart/update/', data);
     const items = await viewCart(user.id);
@@ -79,8 +78,7 @@ export async function updateCartItem(data: UpdateCartData) {
 }
 
 export async function removeFromCart(item_id: number) {
-  const stored = typeof window !== 'undefined' ? localStorage.getItem('user') : null;
-  const user = stored ? JSON.parse(stored) : null;
+  const user = getCurrentUser();
   if (user) {
     const res = await api.post('/cart/remove/', { item_id });
     const items = await viewCart(user.id);

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -13,6 +13,7 @@ import {
   User,
 } from 'firebase/auth';
 import { FirebaseError } from 'firebase/app';
+import { saveCurrentUser, removeCurrentUser, type CurrentUser } from './user';
 
 const firebaseConfig = {
   apiKey: 'AIzaSyBQ-PvQx5TVbQu9wxTdvIpdwmro_uxHeP4',
@@ -115,5 +116,18 @@ export async function firebaseUpdatePassword(newPassword: string) {
 
 export function watchAuth(callback: (user: User | null) => void) {
   const auth = getFirebaseAuth();
-  return onAuthStateChanged(auth, callback);
+  return onAuthStateChanged(auth, (u) => {
+    if (u) {
+      const obj: CurrentUser = {
+        id: u.uid,
+        email: u.email,
+        name: u.displayName,
+      };
+      saveCurrentUser(obj);
+      callback(u);
+    } else {
+      removeCurrentUser();
+      callback(null);
+    }
+  });
 }

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,0 +1,29 @@
+export interface CurrentUser {
+  id: string;
+  email: string | null;
+  name: string | null;
+}
+
+const KEY = 'user';
+
+export function getCurrentUser(): CurrentUser | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = localStorage.getItem(KEY);
+    return stored ? (JSON.parse(stored) as CurrentUser) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCurrentUser(user: CurrentUser) {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(KEY, JSON.stringify(user));
+  }
+}
+
+export function removeCurrentUser() {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(KEY);
+  }
+}


### PR DESCRIPTION
## Summary
- add `getCurrentUser` helpers
- auto-save logged in user in auth listener
- use centralized user retrieval across pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68682bcb9ce4832e8347d1c1d9386736