### PR TITLE
Add StockGrid component for admin stock management

### DIFF
--- a/app/stock/page.tsx
+++ b/app/stock/page.tsx
@@ -1,16 +1,22 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { listStock, updateStock, type StockItem } from '@/lib/stock';
-import { getCurrentUser } from '@/lib/user';
+import { listStock, updateStock } from '@/lib/stock';
+import { getCurrentUser, isAdminEmail } from '@/lib/user';
+import StockGrid, { type StockProduct } from '@/components/StockGrid';
 
 export default function StockPage() {
-  const [items, setItems] = useState<StockItem[]>([]);
+  const [items, setItems] = useState<StockProduct[]>([]);
   const [loading, setLoading] = useState(true);
-  const userId = getCurrentUser()?.id ?? null;
+  const user = getCurrentUser();
+  const userId = user?.id ?? null;
 
   useEffect(() => {
     if (!userId) {
       window.location.href = '/accounts/login';
+      return;
+    }
+    if (!isAdminEmail(user?.email)) {
+      window.location.href = '/';
       return;
     }
     listStock()
@@ -19,7 +25,7 @@ export default function StockPage() {
       .finally(() => setLoading(false));
   }, []);
 
-  const handleUpdate = async (item: StockItem, qty: number) => {
+  const handleUpdate = async (item: StockProduct, qty: number) => {
     const quantity = Math.max(0, qty);
     try {
       await updateStock(item.id, quantity);
@@ -37,37 +43,7 @@ export default function StockPage() {
       {items.length === 0 ? (
         <p>Aucun produit en stock.</p>
       ) : (
-        <table className="w-full border-collapse text-sm">
-          <thead>
-            <tr>
-              <th className="border px-2 py-1 text-left">Produit</th>
-              <th className="border px-2 py-1">Quantité</th>
-              <th className="border px-2 py-1">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((item) => (
-              <tr key={item.id}>
-                <td className="border px-2 py-1">{item.name}</td>
-                <td className="border px-2 py-1 text-center">{item.quantity}</td>
-                <td className="border px-2 py-1 text-center space-x-1">
-                  <button
-                    onClick={() => handleUpdate(item, item.quantity + 1)}
-                    className="px-2 bg-gray-200 rounded-l"
-                  >
-                    +
-                  </button>
-                  <button
-                    onClick={() => handleUpdate(item, item.quantity - 1)}
-                    className="px-2 bg-gray-200 rounded-r"
-                  >
-                    -
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <StockGrid products={items} onUpdate={handleUpdate} />
       )}
     </main>
   );

--- a/components/StockGrid.tsx
+++ b/components/StockGrid.tsx
@@ -1,0 +1,61 @@
+'use client';
+import Image from 'next/image';
+
+export type StockProduct = {
+  id: number;
+  name: string;
+  price?: number;
+  image?: string;
+  reference?: string;
+  quantity: number;
+};
+
+export default function StockGrid({
+  products,
+  onUpdate,
+}: {
+  products: StockProduct[];
+  onUpdate?: (product: StockProduct, qty: number) => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-6">
+      {products.map((p) => (
+        <div key={p.id} className="border rounded-lg p-4 bg-white flex flex-col">
+          {p.image && (
+            <Image
+              src={p.image}
+              alt={p.name}
+              width={300}
+              height={200}
+              className="object-contain mb-2"
+            />
+          )}
+          <h3 className="font-semibold">{p.name}</h3>
+          {p.reference && <p className="text-sm text-gray-500">{p.reference}</p>}
+          {p.price != null && (
+            <p className="mt-auto font-bold">{p.price.toLocaleString()} FCFA</p>
+          )}
+          <div className="mt-2 flex items-center justify-between">
+            <span className="text-sm">Stock: {p.quantity}</span>
+            {onUpdate && (
+              <div className="space-x-1">
+                <button
+                  onClick={() => onUpdate(p, p.quantity + 1)}
+                  className="px-2 bg-gray-200 rounded-l"
+                >
+                  +
+                </button>
+                <button
+                  onClick={() => onUpdate(p, Math.max(0, p.quantity - 1))}
+                  className="px-2 bg-gray-200 rounded-r"
+                >
+                  -
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `StockGrid` component to display products in a responsive grid
- restrict access to `/stock` page to admin users
- use `StockGrid` in the stock management page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68685735f4f0832ebfc2742233e50b74