### PR TITLE
Improve stock workflow with admin navigation

### DIFF
--- a/app/inventory/page.tsx
+++ b/app/inventory/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import {
   listSites,
   createSite,
@@ -83,6 +84,14 @@ export default function InventoryPage() {
   return (
     <main className="container mx-auto py-8 px-4 space-y-6">
       <h1 className="text-2xl font-bold text-center mb-4">Gestion de stock</h1>
+      <div className="flex justify-center gap-4">
+        <Link href="/stock" className="text-blue-600 underline">
+          Voir stock
+        </Link>
+        <Link href="/products/create" className="text-blue-600 underline">
+          Ajouter produit
+        </Link>
+      </div>
 
       <section className="space-y-2">
         <h2 className="font-semibold">Sites</h2>

--- a/app/products/create/page.tsx
+++ b/app/products/create/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { getCurrentUser, isAdminEmail } from '@/lib/user';
+import { createProduct } from '@/lib/products';
+
+export default function CreateProductPage() {
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [reference, setReference] = useState('');
+  const [price, setPrice] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    const user = getCurrentUser();
+    if (!user) {
+      window.location.href = '/accounts/login';
+      return;
+    }
+    if (!isAdminEmail(user.email)) {
+      window.location.href = '/';
+      return;
+    }
+    setLoading(false);
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createProduct({
+        name,
+        slug,
+        reference,
+        price: parseFloat(price) || 0,
+      });
+      setMessage('Produit ajouté');
+      setName('');
+      setSlug('');
+      setReference('');
+      setPrice('');
+    } catch {
+      setMessage("Erreur lors de l'ajout du produit");
+    }
+  };
+
+  if (loading) return <p className="p-4">Chargement...</p>;
+
+  return (
+    <main className="container mx-auto py-8 px-4 space-y-6">
+      <h1 className="text-2xl font-bold text-center mb-4">Ajouter un produit</h1>
+      <div className="flex justify-center gap-4">
+        <Link href="/inventory" className="text-blue-600 underline">
+          Inventaire
+        </Link>
+        <Link href="/stock" className="text-blue-600 underline">
+          Stock
+        </Link>
+      </div>
+      {message && <p className="text-green-600 text-center">{message}</p>}
+      <form onSubmit={handleSubmit} className="space-y-2 max-w-md mx-auto">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Nom"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <input
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder="Slug"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <input
+          value={reference}
+          onChange={(e) => setReference(e.target.value)}
+          placeholder="Référence"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <input
+          type="number"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          placeholder="Prix"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <button
+          type="submit"
+          className="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded"
+        >
+          Créer
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/stock/page.tsx
+++ b/app/stock/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { listStock, updateStock } from '@/lib/stock';
 import { getCurrentUser, isAdminEmail } from '@/lib/user';
 import StockGrid, { type StockProduct } from '@/components/StockGrid';
@@ -40,6 +41,14 @@ export default function StockPage() {
   return (
     <main className="container mx-auto py-8 px-4 space-y-4">
       <h1 className="text-2xl font-bold text-center mb-4">Gestion de stock</h1>
+      <div className="flex justify-center gap-4">
+        <Link href="/inventory" className="text-blue-600 underline">
+          Inventaire
+        </Link>
+        <Link href="/products/create" className="text-blue-600 underline">
+          Ajouter produit
+        </Link>
+      </div>
       {items.length === 0 ? (
         <p>Aucun produit en stock.</p>
       ) : (

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -14,6 +14,8 @@ import {
   FaShoppingCart,
   FaClipboardList,
   FaWarehouse,
+  FaBoxes,
+  FaPlus,
   FaSignInAlt,
   FaInfoCircle,
   FaUser,
@@ -132,7 +134,11 @@ const navLinks: {
   { href: '/cart', label: 'PANIER', icon: <FaShoppingCart />, showCount: true },
   { href: '/orders', label: 'COMMANDES', icon: <FaClipboardList /> },
   ...(user && isAdminEmail(user.email)
-    ? [{ href: '/inventory', label: 'INVENTAIRE', icon: <FaWarehouse /> }]
+    ? [
+        { href: '/inventory', label: 'INVENTAIRE', icon: <FaWarehouse /> },
+        { href: '/stock', label: 'STOCK', icon: <FaBoxes /> },
+        { href: '/products/create', label: 'NOUVEAU', icon: <FaPlus /> },
+      ]
     : []),
   ...(user
     ? [{ href: '/accounts/profile', label: 'MON COMPTE', icon: <FaUser /> }]

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,0 +1,14 @@
+import { api } from './api';
+
+export interface ProductData {
+  name: string;
+  slug: string;
+  reference: string;
+  price: number;
+  [key: string]: any;
+}
+
+export async function createProduct(data: ProductData) {
+  const res = await api.post('/products/create/', data);
+  return res.data;
+}


### PR DESCRIPTION
## Summary
- expose `createProduct` API helper
- add product creation page
- link inventory, stock, and product creation pages together
- show admin navigation entries in the navbar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68685c419f38832e89f4ee5689bde902