### PR TITLE
Fix stock listing to show quantities

### DIFF
--- a/lib/stock.ts
+++ b/lib/stock.ts
@@ -8,8 +8,19 @@ export interface StockItem {
 }
 
 export async function listStock() {
-  const res = await api.get('/stock/');
-  return res.data;
+  const res = await api.get('/products/get-products/');
+  return (res.data as any[]).map((p) => ({
+    id: p.id,
+    name: p.name,
+    quantity: p.stock_quantity ?? 0,
+    reference: p.default_code,
+    price: p.list_price,
+    image: p.image_1024
+      ? p.image_1024.startsWith('http')
+        ? p.image_1024
+        : `${api.defaults.baseURL}${p.image_1024}`
+      : undefined,
+  }));
 }
 
 export async function updateStock(id: number, quantity: number) {


### PR DESCRIPTION
## Summary
- fetch products from `/products/get-products/` to build stock list

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6869a3be6374832eb5f5c6210e92dffc