### PR TITLE
Improve navbar collapsed view

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -184,7 +184,7 @@ const navLinks: {
                   </span>
                 )}
               </span>
-              <span className="">
+              <span className={`${collapsed ? 'hidden' : ''}`}>
                 {label}
               </span>
             </Link>


### PR DESCRIPTION
## Summary
- show only icons when navbar collapses on scroll

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_686a21657998832ea8f9f424888d5b4f