### PR TITLE
Improve SEO metadata

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,13 @@
 'use client';
 import Image from 'next/image';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'À propos',
+  description:
+    "En savoir plus sur Label Retail, spécialiste des solutions de sécurité en Côte d'Ivoire",
+  alternates: { canonical: '/about' },
+};
 
 export default function AboutPage() {
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,25 @@ import Footer from '@/components/Footer';
 import FloatingMenu from '@/components/FloatingMenu';
 import FirebaseInit from '@/components/FirebaseInit';
 import Script from 'next/script';
+import type { Metadata } from 'next';
 import './globals.css';
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://labelretail.ci'),
+  title: {
+    default: 'Label Retail',
+    template: '%s | Label Retail',
+  },
+  description:
+    "Solutions de sécurité électronique et de télécommunication en Côte d'Ivoire",
+  alternates: { canonical: '/' },
+  openGraph: {
+    type: 'website',
+    locale: 'fr_FR',
+    url: 'https://labelretail.ci',
+    siteName: 'Label Retail',
+  },
+};
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,14 @@ import Image from "next/image";
 import { motion } from "framer-motion";
 import axios from "axios";
 import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Accueil",
+  description:
+    "Label Retail - Solutions de sécurité électronique et domotique en Côte d'Ivoire",
+  alternates: { canonical: "/" },
+};
 
 type Product = {
   id: number;

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -4,6 +4,13 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 import ProductCard from '@/components/ProductCard';
 import { addToCart } from '@/lib/cart';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Nos produits',
+  description: "Découvrez notre catalogue complet de solutions Label Retail",
+  alternates: { canonical: '/products' },
+};
 
 type Product = {
   id: number;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Disallow:
 
-Sitemap: https://info@label-ci.com/sitemap.xml
+Sitemap: https://labelretail.ci/sitemap.xml


### PR DESCRIPTION
## Summary
- add site-wide metadata in layout
- include meta tags for homepage, products and about pages
- fix sitemap URL in `robots.txt`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_686a2c3f4794832eb816f07960846e1d