### PR TITLE
Add admin blog pages

### DIFF
--- a/app/blogs/[id]/edit/page.tsx
+++ b/app/blogs/[id]/edit/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { getBlog, updateBlog } from '@/lib/blogs';
+import { getCurrentUser, isAdminEmail } from '@/lib/user';
+
+export default function EditBlogPage() {
+  const params = useParams();
+  const id = params?.id as string | undefined;
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [authorName, setAuthorName] = useState('');
+  const [authorImage, setAuthorImage] = useState<File | null>(null);
+  const [attachments, setAttachments] = useState<FileList | null>(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const user = getCurrentUser();
+    if (!user) {
+      window.location.href = '/accounts/login';
+      return;
+    }
+    if (!isAdminEmail(user.email)) {
+      window.location.href = '/';
+      return;
+    }
+    if (id) {
+      getBlog(id)
+        .then((b) => {
+          setTitle(b.title);
+          setContent(b.content);
+          setAuthorName(b.author_name);
+        })
+        .finally(() => setLoading(false));
+    } else {
+      setLoading(false);
+    }
+  }, [id]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+    const form = new FormData();
+    form.append('title', title);
+    form.append('content', content);
+    form.append('author_name', authorName);
+    if (authorImage) form.append('author_image', authorImage);
+    if (attachments) {
+      Array.from(attachments).forEach((file) => {
+        form.append('attachments', file);
+      });
+    }
+    try {
+      await updateBlog(id, form);
+      router.push(`/blogs/${id}`);
+    } catch {
+      alert("Erreur lors de la mise à jour");
+    }
+  };
+
+  if (loading) return <p className="p-4">Chargement...</p>;
+
+  return (
+    <main className="container mx-auto py-8 px-4 space-y-4 max-w-xl">
+      <h1 className="text-2xl font-bold text-center mb-4">Modifier le Blog</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Titre"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Contenu"
+          className="w-full border px-3 py-2 rounded h-40"
+          required
+        />
+        <input
+          value={authorName}
+          onChange={(e) => setAuthorName(e.target.value)}
+          placeholder="Nom de l'auteur"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <input type="file" accept="image/*" onChange={(e) => setAuthorImage(e.target.files?.[0] || null)} />
+        <input type="file" multiple onChange={(e) => setAttachments(e.target.files)} />
+        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
+          Enregistrer
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/blogs/[id]/page.tsx
+++ b/app/blogs/[id]/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { getBlog, deleteBlog } from '@/lib/blogs';
+import { getCurrentUser, isAdminEmail } from '@/lib/user';
+
+interface BlogDetail {
+  id: number;
+  title: string;
+  content: string;
+  author_name: string;
+  author_image?: string;
+  attachments?: string[];
+  [key: string]: any;
+}
+
+export default function BlogDetailPage() {
+  const params = useParams();
+  const id = params?.id as string | undefined;
+  const [blog, setBlog] = useState<BlogDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const user = getCurrentUser();
+  const isAdmin = isAdminEmail(user?.email);
+
+  useEffect(() => {
+    if (!id) return;
+    getBlog(id)
+      .then(setBlog)
+      .catch(() => setBlog(null))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  const handleDelete = async () => {
+    if (!blog) return;
+    if (!confirm('Supprimer ce blog ?')) return;
+    await deleteBlog(blog.id);
+    window.location.href = '/blogs';
+  };
+
+  if (loading) return <p className="p-4">Chargement...</p>;
+  if (!blog) return <p className="p-4">Blog introuvable.</p>;
+
+  return (
+    <main className="container mx-auto py-8 px-4 space-y-4">
+      <h1 className="text-2xl font-bold">{blog.title}</h1>
+      <p className="italic">Par {blog.author_name}</p>
+      {blog.author_image && (
+        <img src={blog.author_image} alt={blog.author_name} className="w-32 h-32 object-cover rounded" />
+      )}
+      <div dangerouslySetInnerHTML={{ __html: blog.content }} />
+      {blog.attachments && blog.attachments.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="font-semibold">Fichiers</h2>
+          <ul className="list-disc ml-6 space-y-1">
+            {blog.attachments.map((att, idx) => (
+              <li key={idx}>
+                <a href={att} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">
+                  {att.split('/').pop()}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {isAdmin && (
+        <div className="space-x-2">
+          <Link href={`/blogs/${blog.id}/edit`} className="text-blue-600 underline">
+            Modifier
+          </Link>
+          <button onClick={handleDelete} className="text-red-600 underline">
+            Supprimer
+          </button>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/blogs/create/page.tsx
+++ b/app/blogs/create/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { createBlog } from '@/lib/blogs';
+import { getCurrentUser, isAdminEmail } from '@/lib/user';
+
+export default function CreateBlogPage() {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [authorName, setAuthorName] = useState('');
+  const [authorImage, setAuthorImage] = useState<File | null>(null);
+  const [attachments, setAttachments] = useState<FileList | null>(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const user = getCurrentUser();
+    if (!user) {
+      window.location.href = '/accounts/login';
+      return;
+    }
+    if (!isAdminEmail(user.email)) {
+      window.location.href = '/';
+      return;
+    }
+    setAuthorName(user.name || user.email || '');
+    setLoading(false);
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const form = new FormData();
+    form.append('title', title);
+    form.append('content', content);
+    form.append('author_name', authorName);
+    if (authorImage) form.append('author_image', authorImage);
+    if (attachments) {
+      Array.from(attachments).forEach((file) => {
+        form.append('attachments', file);
+      });
+    }
+    try {
+      const blog = await createBlog(form);
+      router.push(`/blogs/${blog.id}`);
+    } catch {
+      alert("Erreur lors de la création du blog");
+    }
+  };
+
+  if (loading) return <p className="p-4">Chargement...</p>;
+
+  return (
+    <main className="container mx-auto py-8 px-4 space-y-4 max-w-xl">
+      <h1 className="text-2xl font-bold text-center mb-4">Nouveau Blog</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Titre"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Contenu"
+          className="w-full border px-3 py-2 rounded h-40"
+          required
+        />
+        <input
+          value={authorName}
+          onChange={(e) => setAuthorName(e.target.value)}
+          placeholder="Nom de l'auteur"
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setAuthorImage(e.target.files?.[0] || null)}
+        />
+        <input
+          type="file"
+          multiple
+          onChange={(e) => setAttachments(e.target.files)}
+        />
+        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
+          Créer
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { listBlogs, deleteBlog } from '@/lib/blogs';
+import { getCurrentUser, isAdminEmail } from '@/lib/user';
+
+interface Blog {
+  id: number;
+  title: string;
+  author_name: string;
+  [key: string]: any;
+}
+
+export default function BlogsPage() {
+  const [blogs, setBlogs] = useState<Blog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const user = getCurrentUser();
+  const isAdmin = isAdminEmail(user?.email);
+
+  useEffect(() => {
+    listBlogs()
+      .then(setBlogs)
+      .catch(() => setBlogs([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('Supprimer ce blog ?')) return;
+    await deleteBlog(id);
+    setBlogs(blogs.filter((b) => b.id !== id));
+  };
+
+  if (loading) return <p className="p-4">Chargement...</p>;
+
+  return (
+    <main className="container mx-auto py-8 px-4 space-y-4">
+      <h1 className="text-2xl font-bold text-center mb-4">Blogs</h1>
+      {isAdmin && (
+        <div className="text-center">
+          <Link href="/blogs/create" className="text-blue-600 underline">
+            Nouveau blog
+          </Link>
+        </div>
+      )}
+      {blogs.length === 0 ? (
+        <p>Aucun blog disponible.</p>
+      ) : (
+        <ul className="space-y-2">
+          {blogs.map((blog) => (
+            <li key={blog.id} className="border p-3 rounded flex justify-between items-center">
+              <Link href={`/blogs/${blog.id}`}>{blog.title}</Link>
+              {isAdmin && (
+                <div className="space-x-2">
+                  <Link href={`/blogs/${blog.id}/edit`} className="text-blue-600 underline">
+                    Modifier
+                  </Link>
+                  <button onClick={() => handleDelete(blog.id)} className="text-red-600 underline">
+                    Supprimer
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -18,6 +18,7 @@ import {
   FaPlus,
   FaSignInAlt,
   FaInfoCircle,
+  FaNewspaper,
   FaUser,
 } from 'react-icons/fa';
 
@@ -138,6 +139,7 @@ const navLinks: {
   ...(user
     ? [{ href: '/accounts/profile', label: 'MON COMPTE', icon: <FaUser /> }]
     : [{ href: '/accounts/login', label: 'CONNEXION', icon: <FaSignInAlt /> }]),
+  { href: '/blogs', label: 'BLOG', icon: <FaNewspaper /> },
   { href: '/about', label: 'A PROPOS', icon: <FaInfoCircle /> },
 ];
 

--- a/lib/blogs.ts
+++ b/lib/blogs.ts
@@ -1,0 +1,40 @@
+import { api } from './api';
+
+export interface BlogData {
+  id?: number;
+  title: string;
+  content: string;
+  author_name: string;
+  author_image?: File | string | null;
+  attachments?: File[];
+  [key: string]: any;
+}
+
+export async function listBlogs() {
+  const res = await api.get('/blogs/');
+  return res.data;
+}
+
+export async function getBlog(id: number | string) {
+  const res = await api.get(`/blogs/${id}/`);
+  return res.data;
+}
+
+export async function createBlog(data: FormData) {
+  const res = await api.post('/blogs/create/', data, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data;
+}
+
+export async function updateBlog(id: number | string, data: FormData) {
+  const res = await api.post(`/blogs/${id}/update/`, data, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data;
+}
+
+export async function deleteBlog(id: number | string) {
+  const res = await api.delete(`/blogs/${id}/delete/`);
+  return res.data;
+}


### PR DESCRIPTION
## Summary
- enable blog API support
- list blogs with admin actions
- allow creating a blog
- allow editing a blog
- display single blog page
- link to blogs in navbar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686a30edae68832e875321f2dc0e059e