### PR TITLE
Group products by category on product page

### DIFF
--- a/components/ProductsPageClient.tsx
+++ b/components/ProductsPageClient.tsx
@@ -32,15 +32,26 @@ function getProductImage(product: Product): string {
   return '/default-product.png';
 }
 
+interface ProductsByCategory {
+  [category: string]: Product[];
+}
+
 export default function ProductsPageClient() {
-  const [products, setProducts] = useState<Product[]>([]);
+  const [grouped, setGrouped] = useState<ProductsByCategory>({});
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     api
       .get('/products/get-products/')
       .then((res) => {
-        setProducts(res.data);
+        const products = res.data as Product[];
+        const groups: ProductsByCategory = {};
+        products.forEach((p) => {
+          const category = (p as any).categ_id || 'Autres';
+          if (!groups[category]) groups[category] = [];
+          groups[category].push(p);
+        });
+        setGrouped(groups);
         setIsLoading(false);
       })
       .catch((error) => {
@@ -60,34 +71,41 @@ export default function ProductsPageClient() {
   return (
     <main className="container mx-auto py-8">
       <h1 className="text-3xl font-bold text-center mb-8">Nos Produits</h1>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {products.map((product) => {
-          const imageUrl = getProductImage(product);
-          const whatsappLink = `https://wa.me/22588899965?text=${encodeURIComponent(
-            `Bonjour, je souhaite acheter le produit : ${product.name} (Réf : ${product.default_code}).`
-          )}`;
-          const handleAdd = async () => {
-            await addToCart({
-              product_id: product.id,
-              quantity: 1,
-              product_name: product.name,
-              product_image: imageUrl,
-              price: product.list_price,
-            });
-          };
-          return (
-            <ProductCard
-              key={product.id}
-              imageUrl={imageUrl}
-              name={product.name}
-              reference={product.default_code || ''}
-              price={product.list_price}
-              whatsappLink={whatsappLink}
-              onAddToCart={handleAdd}
-            />
-          );
-        })}
-      </div>
+      {Object.entries(grouped).map(([category, products]) => (
+        <section key={category} className="mb-10">
+          <h2 className="text-2xl font-semibold text-orange-600 mb-4">
+            {category}
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {products.map((product) => {
+              const imageUrl = getProductImage(product);
+              const whatsappLink = `https://wa.me/22588899965?text=${encodeURIComponent(
+                `Bonjour, je souhaite acheter le produit : ${product.name} (Réf : ${product.default_code}).`
+              )}`;
+              const handleAdd = async () => {
+                await addToCart({
+                  product_id: product.id,
+                  quantity: 1,
+                  product_name: product.name,
+                  product_image: imageUrl,
+                  price: product.list_price,
+                });
+              };
+              return (
+                <ProductCard
+                  key={product.id}
+                  imageUrl={imageUrl}
+                  name={product.name}
+                  reference={product.default_code || ''}
+                  price={product.list_price}
+                  whatsappLink={whatsappLink}
+                  onAddToCart={handleAdd}
+                />
+              );
+            })}
+          </div>
+        </section>
+      ))}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- fetch all products in ProductsPageClient and group them by `categ_id`
- render each product category in sections on the products page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686a3ad2442c832eba46675451d203b4