### PR TITLE
Add search page

### DIFF
--- a/app/search/not-found.tsx
+++ b/app/search/not-found.tsx
@@ -1,0 +1,14 @@
+'use client';
+import Link from 'next/link';
+
+export default function SearchNotFound() {
+  return (
+    <main className="min-h-[50vh] flex flex-col items-center justify-center text-center space-y-4">
+      <h1 className="text-2xl font-bold text-orange-500">Aucun produit trouvé</h1>
+      <p>Essayez une autre recherche.</p>
+      <Link href="/" className="text-blue-600 underline">
+        Retour à l'accueil
+      </Link>
+    </main>
+  );
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,46 @@
+import { notFound } from 'next/navigation';
+import SearchResultsClient from '@/components/SearchResultsClient';
+
+interface Product {
+  id: number;
+  name: string;
+  slug: string;
+  image_1024?: string;
+  default_code?: string;
+  list_price: number;
+  [key: string]: unknown;
+}
+
+async function getProducts(q: string): Promise<Product[]> {
+  const res = await fetch(
+    `https://labelshop-backend.onrender.com/products/search-products/?q=${encodeURIComponent(q)}`,
+    { cache: 'no-store' }
+  );
+  if (!res.ok) {
+    return [];
+  }
+  const data = await res.json();
+  return Array.isArray(data) ? data : [];
+}
+
+export default async function SearchPage({
+  searchParams,
+}: {
+  searchParams: { q?: string };
+}) {
+  const q = searchParams.q?.toString().trim() ?? '';
+  if (!q) {
+    return (
+      <main className="p-4 text-center">
+        <p>Saisissez un terme dans la barre de recherche.</p>
+      </main>
+    );
+  }
+
+  const products = await getProducts(q);
+  if (products.length === 0) {
+    notFound();
+  }
+
+  return <SearchResultsClient products={products} query={q} />;
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -42,7 +42,7 @@ export default function Navbar() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (searchQuery.trim()) {
-      router.push(`/products/${searchQuery}`);
+      router.push(`/search?q=${encodeURIComponent(searchQuery)}`);
       setSearchQuery('');
       setSuggestions([]);
     }

--- a/components/SearchResultsClient.tsx
+++ b/components/SearchResultsClient.tsx
@@ -1,0 +1,65 @@
+'use client';
+import ProductCard from '@/components/ProductCard';
+import { addToCart } from '@/lib/cart';
+
+interface Product {
+  id: number;
+  name: string;
+  slug: string;
+  image_1024?: string;
+  default_code?: string;
+  list_price: number;
+  [key: string]: unknown;
+}
+
+function getImageUrl(product: Product): string {
+  const baseUrl = 'https://labelshop-backend.onrender.com';
+  if (product.image_1024 && typeof product.image_1024 === 'string') {
+    return product.image_1024.startsWith('http')
+      ? `${product.image_1024}?t=${Date.now()}`
+      : `${baseUrl}${product.image_1024}?t=${Date.now()}`;
+  }
+  return '/default-product.png';
+}
+
+export default function SearchResultsClient({
+  products,
+  query,
+}: {
+  products: Product[];
+  query: string;
+}) {
+  return (
+    <main className="container mx-auto py-8">
+      <h1 className="text-2xl font-bold mb-4">Résultats pour {query}</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {products.map((product) => {
+          const imageUrl = getImageUrl(product);
+          const whatsappLink = `https://wa.me/22588899965?text=${encodeURIComponent(
+            `Bonjour, je souhaite acheter le produit : ${product.name} (Réf : ${product.default_code}).`
+          )}`;
+          const handleAdd = async () => {
+            await addToCart({
+              product_id: product.id,
+              quantity: 1,
+              product_name: product.name,
+              product_image: imageUrl,
+              price: product.list_price,
+            });
+          };
+          return (
+            <ProductCard
+              key={product.id}
+              imageUrl={imageUrl}
+              name={product.name}
+              reference={product.default_code || ''}
+              price={product.list_price}
+              whatsappLink={whatsappLink}
+              onAddToCart={handleAdd}
+            />
+          );
+        })}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add search results client component
- create server-side search page
- add not-found page for search
- hook up navbar search to new route

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_688254f9d7d0832eb0bdecce8ef9575d