### PR TITLE
Group products by main categories

### DIFF
--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, ResolvingMetadata } from 'next';
 import AddToCart from '@/components/AddToCart';
+import { mapCategory } from '@/lib/category';
 
 // 🔁 Récupère l'image
 function getImageUrl(product: any): string {
@@ -144,7 +145,9 @@ export default async function ProductDetailPage({
           </div>
 
           <div className="mt-4 text-sm text-gray-700 space-y-1">
-            <p><strong>Catégorie :</strong> {product.categ_id}</p>
+            <p>
+              <strong>Catégorie :</strong> {mapCategory(product.categ_id)}
+            </p>
             <p><strong>Marque :</strong> {product.brand || 'Hikvision'}</p>
             <p><strong>Référence :</strong> {product.default_code}</p>
           </div>

--- a/app/products/categories/page.tsx
+++ b/app/products/categories/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 import ProductCard from '@/components/ProductCard';
 import { addToCart } from '@/lib/cart';
+import { mapCategory, MAIN_CATEGORIES } from '@/lib/category';
 
 interface Product {
   id: number;
@@ -31,7 +32,7 @@ export default function ProductsByCategoryPage() {
         const products = res.data as Product[];
         const groups: ProductsByCategory = {};
         products.forEach((p) => {
-          const category = p.categ_id || 'Autres';
+          const category = mapCategory(p.categ_id);
           if (!groups[category]) groups[category] = [];
           groups[category].push(p);
         });
@@ -55,11 +56,11 @@ export default function ProductsByCategoryPage() {
   return (
     <main className="container mx-auto py-8">
       <h1 className="text-3xl font-bold text-center mb-8">Produits par catégorie</h1>
-      {Object.entries(grouped).map(([category, products]) => (
+      {MAIN_CATEGORIES.filter((c) => grouped[c]).map((category) => (
         <section key={category} className="mb-10">
           <h2 className="text-2xl font-semibold text-orange-600 mb-4">{category}</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {products.map((product) => {
+            {grouped[category].map((product) => {
               const imageUrl = product.image_1024?.startsWith('http')
                 ? `${product.image_1024}?t=${Date.now()}`
                 : `https://labelshop-backend.onrender.com${product.image_1024}?t=${Date.now()}`;

--- a/components/ProductsPageClient.tsx
+++ b/components/ProductsPageClient.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 import ProductCard from '@/components/ProductCard';
 import { addToCart } from '@/lib/cart';
+import { mapCategory, MAIN_CATEGORIES } from '@/lib/category';
 
 type Product = {
   id: number;
@@ -47,7 +48,7 @@ export default function ProductsPageClient() {
         const products = res.data as Product[];
         const groups: ProductsByCategory = {};
         products.forEach((p) => {
-          const category = (p as any).categ_id || 'Autres';
+          const category = mapCategory((p as any).categ_id);
           if (!groups[category]) groups[category] = [];
           groups[category].push(p);
         });
@@ -71,13 +72,13 @@ export default function ProductsPageClient() {
   return (
     <main className="container mx-auto py-8">
       <h1 className="text-3xl font-bold text-center mb-8">Nos Produits</h1>
-      {Object.entries(grouped).map(([category, products]) => (
+      {MAIN_CATEGORIES.filter((c) => grouped[c]).map((category) => (
         <section key={category} className="mb-10">
           <h2 className="text-2xl font-semibold text-orange-600 mb-4">
             {category}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {products.map((product) => {
+            {grouped[category].map((product) => {
               const imageUrl = getProductImage(product);
               const whatsappLink = `https://wa.me/22588899965?text=${encodeURIComponent(
                 `Bonjour, je souhaite acheter le produit : ${product.name} (Réf : ${product.default_code}).`

--- a/lib/category.ts
+++ b/lib/category.ts
@@ -1,0 +1,59 @@
+export const CATEGORY_HIERARCHY: Record<string, string[]> = {
+  'Vid\u00e9o analogique': ['Cam\u00e9ras PTZ', 'Cam\u00e9ras fixes', 'DVR'],
+  'Vid\u00e9o IP': [
+    'Cam\u00e9ras PTZ',
+    'Cam\u00e9ras fixes',
+    'NVR',
+    'Switches PoE',
+    'Stockage IP SAN/NAS',
+  ],
+  'Hybride/HCVR': ['DVR Hybride'],
+  "Contr\u00f4le d\u2019acc\u00e8s & Interphonie": [
+    'Interphonie vid\u00e9o',
+    'Door station',
+    'Indoor station',
+    'Contr\u00f4leurs & lecteurs',
+  ],
+  'Alarme intrusion': [
+    'Centrales',
+    'D\u00e9tecteurs / contacts / sir\u00e8nes',
+    'P\u00e9riph\u00e9riques',
+  ],
+  'Affichage & mur d\u2019images': ['Moniteurs', 'D\u00e9coders / contr\u00f4leurs'],
+  'Autres sp\u00e9cialisations': [
+    'Mobile / Bodycam',
+    'Traffic / radar',
+    'Thermique',
+  ],
+  'Accessoires g\u00e9n\u00e9raux': [
+    'C\u00e2bles & connectique',
+    'Disques durs',
+    'Supports & bo\u00eetiers',
+  ],
+};
+
+export const MAIN_CATEGORIES = [
+  'Vid\u00e9o analogique',
+  'Vid\u00e9o IP',
+  'Hybride/HCVR',
+  "Contr\u00f4le d\u2019acc\u00e8s & Interphonie",
+  'Alarme intrusion',
+  'Affichage & mur d\u2019images',
+  'Autres sp\u00e9cialisations',
+  'Accessoires g\u00e9n\u00e9raux',
+  'Non class\u00e9',
+];
+
+export function mapCategory(raw?: string): string {
+  if (!raw) return 'Non class\u00e9';
+  const normalized = raw.toLowerCase();
+  for (const [main, subs] of Object.entries(CATEGORY_HIERARCHY)) {
+    if (normalized.includes(main.toLowerCase())) {
+      return main;
+    }
+    if (subs.some((sub) => normalized.includes(sub.toLowerCase()))) {
+      return main;
+    }
+  }
+  return 'Non class\u00e9';
+}


### PR DESCRIPTION
## Summary
- map product category names to main categories
- group products by predefined categories on Products pages
- show mapped categories on product details

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68825f4a72dc832e9a7766966399429a