### PR TITLE
fix(products): drop credentialed axios for public product fetch

### DIFF
--- a/components/ProductsPageClient.tsx
+++ b/components/ProductsPageClient.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import axios from 'axios';
 import ProductCard from '@/components/ProductCard';
 import { addToCart } from '@/lib/cart';
 import { mapProductCategory, MAIN_CATEGORIES } from '@/lib/category';
-import { api, apiUrl } from '@/lib/api';
+import { apiUrl } from '@/lib/api';
 
 type Product = {
   id: number;
@@ -39,8 +40,8 @@ export default function ProductsPageClient() {
   const [selectedCategory, setSelectedCategory] = useState('Toutes les catégories');
 
   useEffect(() => {
-    api
-      .get('/products/get-products/')
+    axios
+      .get(apiUrl('/products/get-products/'))
       .then((res) => {
         const products = res.data as Product[];
         const groups: ProductsByCategory = {};


### PR DESCRIPTION
## Summary

La page `/products` restait bloquée sur « Chargement des produits… ».

Le refactor `b24e662` (centralisation de `NEXT_PUBLIC_API_URL`) a migré `ProductsPageClient` sur l'instance `api` partagée de `lib/api.ts`, qui inclut `withCredentials: true` pour faire transiter le cookie de session sur les routes authentifiées (panier, comptes…). Mais `/products/get-products/` est public et la politique CORS du backend rejette les pré-vérifications créditées pour cet endpoint — d'où l'échec silencieux.

Les autres consommateurs publics (`HomePageClient`, `Navbar`, `ProductsByCategoryClient`) utilisent déjà `axios.get(apiUrl(...))` sans credentials. Cette PR aligne `ProductsPageClient` sur le même pattern.

## Test plan

- [ ] `npm run dev` puis ouvrir `/products` → la liste s'affiche, plus de blocage sur le loader
- [ ] Vérifier qu'au moins une catégorie est rendue et que le filtre fonctionne
- [ ] Vérifier que les images produit (`apiUrl(image_1024)`) se chargent toujours
- [ ] Régression : `/cart` et `/accounts` continuent à utiliser `api` avec credentials

https://claude.ai/code/session_01Gk7EHpXasuWhyqRBeodZV1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk7EHpXasuWhyqRBeodZV1)_